### PR TITLE
Update PSGallery Source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ commands:
             Set-AWSCredential -AccessKey:($env:AWS_ACCESS_KEY_ID) -SecretKey:($env:AWS_SECRET_ACCESS_KEY)
             $CARepoEndpoint = "$(Get-CARepositoryEndpoint -Domain jumpcloud-artifacts -Region us-east-1 -Repository jumpcloud-nuget-modules -Format nuget)v3/index.json"
             dotnet nuget add source $CARepoEndpoint --name CodeArtifact --username aws --password (Get-CAAuthorizationToken -Domain:("jumpcloud-artifacts") -Region:("us-east-1")).AuthorizationToken
-            dotnet nuget add source "https://www.powershellgallery.com/api/v2" --name PSGallery
+            dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
   build-test:
     parameters:
       SDKName:


### PR DESCRIPTION
## Issues
* [SA-2262](https://jumpcloud.atlassian.net/browse/SA-2262) - Update NuGet Source to Publish to PSGallery

## What does this solve?

Change the nuget source from "https://www.powershellgallery.com/api/v2/" to "https://www.powershellgallery.com/api/v2/package". When publishing a package to the former url, dotnet nuget throws an error stating that the method post is not allowed

## Is there anything particularly tricky?

No, the same fix had to be applied to the PowerShell Module months ago: See CI Build [before the updated url](https://app.circleci.com/pipelines/github/TheJumpCloud/support/246/workflows/45f31d2a-7672-4e0c-91de-86d476a0f57a/jobs/781) - and [after](https://app.circleci.com/pipelines/github/TheJumpCloud/support/350/workflows/099adee5-49bd-4425-aaf5-93d13e04e7f0/jobs/1229?invite=true#step-107-7)

## How should this be tested?

## Screenshots
<img width="931" alt="Screen Shot 2022-01-11 at 12 55 42 PM" src="https://user-images.githubusercontent.com/54448601/149012091-776d2b3a-e36f-4c74-9bbe-a11ea6f53418.png">