### PR TITLE
Update Nuget Sources on Push Step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,6 +626,10 @@ commands:
           name: Publishing to "<< parameters.source >>" repo
           shell: pwsh.exe
           command: |
+            # finally remove source PSGallery and add again with the v2/package path for publishing
+            dotnet nuget remove source PSGallery
+            dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
+
             $NupkgPath = (Get-ChildItem -Path:("./SDKs/PowerShell/<< parameters.SDKName >>/bin/nupkg/<< parameters.SDKName >>*.nupkg")).FullName
             If('<< parameters.source >>' -eq 'CodeArtifact'){dotnet nuget push $NupkgPath --source << parameters.source >>}
             ElseIf('<< parameters.source >>' -eq 'PSGallery'){dotnet nuget push $NupkgPath --source << parameters.source >> --api-key $env:NuGetApiKey}


### PR DESCRIPTION
## Issues
* [SA-3081](https://jumpcloud.atlassian.net/browse/SA-3081) - Update Nuget Sources for Pack and Deploy steps

## What does this solve?

I had hoped #53 would address this issue entirely, what I'm finding is that the pack and deploy steps in this repo are having trouble identifying the PSGalley source and I'm not entirely sure why. 

In #53 we updated the PSGallery source url to be `https://www.powershellgallery.com/api/v2` from `https://www.powershellgallery.com/api/v2/package` — This addressed the issue with `nuget pack` not able to find the package to pack from PSGallery however it broke the publish and deploy step. It looks like we still want to point our deployment packages to `https://www.powershellgallery.com/api/v2/package` so this release simply updates the PSGallery source url before attempting to release. 

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots