### PR TITLE
Cut 3982 auto generate examples

### DIFF
--- a/Tools/Build-SdkExamples.ps1
+++ b/Tools/Build-SdkExamples.ps1
@@ -150,11 +150,26 @@ foreach ($item in $list) {
 
         # Build the example string for the set
         $string = "$($item.functionName)"
+
+        # account for clear type verb actions:
+        if ($item.functionType -eq "Clear"){
+            # find the clear item, so it's not using the default .clear method when we call it
+            for ($i = 0; $i -lt $paramInfo.Count; $i++) {
+                <# Action that will repeat until the condition is met #>
+                if ($paramInfo[$i].Clear){
+                    $clearNum = $i
+                }
+            }
+            $parmSetCount = $paramInfo[$clearNum].$Set.Count
+        } else {
+            $parmSetCount = $paramInfo.$Set.Count
+        }
         # $descriptionString = "$($item.functionType) a $($item.functionBaseType) by"
-        for ($i = 0; $i -lt $paramInfo.$Set.Count; $i++) {
+
+        for ($i = 0; $i -lt $parmSetCount; $i++) {
             <# Action that will repeat until the condition is met #>
             if ($set -eq 'clear'){
-                $paramText = $paramInfo[0].$Set[$i]
+                $paramText = $paramInfo[$clearNum].$Set[$i]
             } else {
                 $paramText = $paramInfo.$Set[$i]
             }
@@ -178,7 +193,7 @@ foreach ($item in $list) {
                 $descriptionVerb = get-verb "$($item.functionType)"
                 $descriptionString = "$descriptionVerb $a_an $($item.functionBaseType)"
                 if ($set -eq 'clear'){
-                    $paramText = $paramInfo[0].$Set | Where-Object {$_.parameterMandatory -eq $true}
+                    $paramText = $paramInfo[$clearNum].$Set | Where-Object {$_.parameterMandatory -eq $true}
                 } else {
                     $paramText = $paramInfo.$Set | Where-Object {$_.parameterMandatory -eq $true}
                 }

--- a/Tools/Build-SdkExamples.ps1
+++ b/Tools/Build-SdkExamples.ps1
@@ -1,0 +1,247 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true, HelpMessage = 'Name of the API to build an SDK for.')][ValidateSet('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2')][ValidateNotNullOrEmpty()]
+    [System.String[]]
+    $SDKName #= 'JumpCloud.SDK.V1'
+)
+$rootPath = "$PSScriptRoot/../"
+# examples:
+$examples = Get-ChildItem -Path "$rootPath/SDKs/PowerShell/$SDKName/examples" -Filter "*.md"
+$functions = Get-ChildItem -Path "$rootPath/SDKs/PowerShell/$SDKName/custom/generated" -Filter "*.ps1"
+
+$list = New-Object System.Collections.ArrayList
+function get-verb {
+    [CmdletBinding()]
+    param (
+        $string
+    )
+
+    begin {
+        $VerbMap = @{
+            'New' = 'Create'
+        }
+
+    }
+
+    process {
+        if ($string -in $VerbMap.Keys){
+            $matchedVerb = $VerbMap["$string"]
+        } else {
+            $matchedVerb = $string
+        }
+
+    }
+
+    end {
+        return $matchedVerb
+    }
+}
+
+function Get-WordStartsWithVowel {
+    [CmdletBinding()]
+    param (
+        $string
+    )
+
+    begin {
+        $firstLetter = $string[0]
+    }
+
+    process {
+        if (($firstLetter -eq 'a') -or ($firstLetter -eq 'e') -or ($firstLetter -eq 'i') -or ($firstLetter -eq 'o') -or ($firstLetter -eq 'u') -or ($firstLetter -eq 'y')){
+            $startsWithVowel = $true
+        } else {
+            $startsWithVowel = $false
+        }
+    }
+
+    end {
+        return $startsWithVowel
+    }
+}
+
+function Get-FunctionInformation {
+    [CmdletBinding()]
+    param (
+        $CommandName
+    )
+
+    begin {
+        $command = (Get-Command -Name $CommandName);
+        $functionHelpParams = Get-Help $CommandName -Parameter *
+        $functionMandatoryParams = $functionHelpParams | Where-Object {$_.required -eq $true}
+
+    }
+
+    process {
+        $parameterList = New-Object System.Collections.ArrayList
+        foreach ($item in $command.parameters.keys){
+            if ($item -in $functionMandatoryParams.name){
+                $parameterList.Add(
+                    [PSCustomObject]@{
+                        Name = $item;
+                        Required = $true
+                        ParameterSets = $command.parameters.$item.ParameterSets
+                        ParameterType = $command.parameters.$item.ParameterType
+                    }
+                ) | Out-Null
+            } else {
+                $parameterList.Add(
+                    [PSCustomObject]@{
+                        Name = $item;
+                        Required = $false
+                        ParameterSets = $command.parameters.$item.ParameterSets
+                        ParameterType = $command.parameters.$item.ParameterType
+                    }
+                ) | Out-Null
+            }
+        }
+        $commandInfo = [PSCustomObject]@{
+            parameterSets = $command.ParameterSets.Name
+            parameters = $parameterList
+        }
+    }
+
+    end {
+        return $commandInfo
+    }
+}
+
+foreach ($item in $functions){
+    $functionName = $item.BaseName -replace ".ps1", ""
+    $functionItem = [PSCustomObject]@{
+        functionName = $functionName
+        functionType = ($functionName -split ('-'))[0]
+        functionBaseType = ($functionName -split ('-'))[1].Replace('JcSdk','')
+        functionPath = $item.FullName
+        examplePath = ($examples | Where-Object {$_.Name -eq "$($functionName).md"}).FullName
+        functionInfo = Get-FunctionInformation -CommandName $functionName;
+    }
+    $list.Add($functionItem) | Out-Null
+}
+
+
+$outputList = New-Object System.Collections.Hashtable
+
+foreach ($item in $list) {
+    write-warning "Building SDK Documentation: $($item.functionName)"
+    $outputList.add($item.functionName, (New-Object System.Collections.Hashtable))
+    $paramInfo = New-Object system.Collections.ArrayList
+    foreach ($set in $item.functionInfo.parameterSets | Where-Object {$_ -notmatch "ViaIdentity"}){
+        # Write-Warning $set
+        $setList = New-Object system.Collections.ArrayList
+        $item.functionInfo.parameters.GetEnumerator() | ForEach-Object {
+            $paramName = $_ | Where-Object {$_.ParameterSets.Keys -eq $set}
+            if ($paramName){
+                $setList.Add(
+                    [PSCustomObject]@{
+                        parameterName = $paramName.name
+                        parameterValueType = $_.ParameterType
+                        parameterMandatory = $_.Required
+                    }
+                ) | Out-Null
+            }
+        }
+        $paramInfo.Add(
+            [PSCustomObject]@{
+                $set = $setList
+            }
+        ) | Out-Null
+
+        # Build the example string for the set
+        $string = "$($item.functionName)"
+        # $descriptionString = "$($item.functionType) a $($item.functionBaseType) by"
+        for ($i = 0; $i -lt $paramInfo.$Set.Count; $i++) {
+            <# Action that will repeat until the condition is met #>
+            if ($set -eq 'clear'){
+                $paramText = $paramInfo[0].$Set[$i]
+            } else {
+                $paramText = $paramInfo.$Set[$i]
+            }
+            if ($paramText.ParameterName) {
+                $string += " -$($paramText.ParameterName):(<$($($paramText.parameterValueType))>)"
+            }
+        }
+        # replace internal model name with non-internal model that can be publically used
+        $string = $string.Replace('.Models.I', '.Models.')
+        switch ($set) {
+            'List' {
+                $descriptionString = "List $($item.functionBaseType)s"
+            }
+            Default {
+                # an vs a
+                $vowel = Get-WordStartsWithVowel $($item.functionBaseType)
+                switch ($vowel) {
+                    $true { $a_an = "an" }
+                    $false { $a_an = "a" }
+                }
+                $descriptionVerb = get-verb "$($item.functionType)"
+                $descriptionString = "$descriptionVerb $a_an $($item.functionBaseType)"
+                if ($set -eq 'clear'){
+                    $paramText = $paramInfo[0].$Set | Where-Object {$_.parameterMandatory -eq $true}
+                } else {
+                    $paramText = $paramInfo.$Set | Where-Object {$_.parameterMandatory -eq $true}
+                }
+                $ParamTextlist = $($paramText.parameterName)
+                if ($ParamTextlist.count -eq 1){
+                    $descriptionString += " by $ParamTextlist"
+                } else {
+                    $descriptionString += " by"
+                    for ($i = 0; $i -lt $ParamTextlist.Count; $i++) {
+                        <# Action that will repeat until the condition is met #>
+                        if ($i+1 -eq $ParamTextlist.Count){
+                            $descriptionString += " and $($ParamTextlist[$i])"
+
+                        } else {
+                            $descriptionString += " $($ParamTextlist[$i]),"
+                        }
+                    }
+
+                }
+            }
+        }
+        # add the example to the $outputlist variable
+        $outputList["$($item.functionName)"].add($set,[PSCustomObject]@{
+            example = $string;
+            description = "$($descriptionString)";
+        })
+    }
+}
+
+# Write the examples
+foreach ($item in $list){
+    $functionExamples = $outputList["$($item.functionName)"]
+
+    # Get the content of the example file:
+    $exampleContent = Get-Content $item.examplePath -Raw
+    # Set Names
+    $setList = New-Object System.Collections.ArrayList
+    $setNames = $functionExamples.getEnumerator().name
+    foreach ($set in $setNames){
+        $setLIst.Add($set) | Out-Null
+    }
+
+    If ($setLIst.count -eq 1) {
+        $array = New-Object System.Collections.ArrayList
+        $array.add($setLIst) | Out-Null
+        $setLIst = $array
+    }
+
+    for ($i = 0; $i -lt $setList.Count; $i++) {
+        # TODO: figure out cases with > 2 sets
+        <# Action that will repeat until the condition is met #>
+        if ($exampleContent -match "\#\#\# Example $($i+1): {{ Add title here }}") {
+            $exampleContent = $exampleContent.replace("### Example $($i+1): {{ Add title here }}", "### Example $($i+1): $((invoke-expression -command ('$functionexamples.' + $setList[$i])).description)")
+
+            $exampleRegex = [regex]"### Example $($i+1)[\s\S]*?(?={{ Add description here }})"
+            $cc = $exampleContent | Select-String -Pattern $exampleRegex
+            # content to edit:
+            $ContentToEdit = $cc.Matches.Value
+            $ReplacedContent = $ContentToEdit -replace ("{{ Add code here }}", $((invoke-expression -command ('$functionexamples.' + $setList[$i])).example))
+            # update example:
+            $currentContent = Get-Content -Path $item.examplePath -Raw
+            $currentContent -replace ($exampleRegex, $ReplacedContent) | Set-Content -Path $item.examplePath -NoNewline -Force
+
+        }
+    }
+}

--- a/Tools/Build-SdkExamples.ps1
+++ b/Tools/Build-SdkExamples.ps1
@@ -1,8 +1,8 @@
 [CmdletBinding()]
 param (
-    [Parameter(HelpMessage = 'Name of the API to build an SDK for.')][ValidateSet('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2')][ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory, HelpMessage = 'Name of the API to build an SDK for.')][ValidateSet('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2')][ValidateNotNullOrEmpty()]
     [System.String[]]
-    $SDKName = 'JumpCloud.SDK.V1'
+    $SDKName
 )
 $rootPath = "$PSScriptRoot/../"
 # examples:
@@ -202,7 +202,7 @@ foreach ($item in $list) {
                 $ParamTextlist = $($paramText.parameterName)
                 if ($ParamTextlist.count -eq 1){
                     $descriptionString += " by $ParamTextlist"
-                    $deatiledDescriptionString += " by $ParamTextlist. $ParamTextlist is a required parameter"
+                    $deatiledDescriptionString += " by $ParamTextlist. $ParamTextlist is a required parameter."
                 } else {
                     $descriptionString += " by"
                     $deatiledDescriptionString += " by $ParamTextlist."
@@ -210,7 +210,7 @@ foreach ($item in $list) {
                         <# Action that will repeat until the condition is met #>
                         if ($i+1 -eq $ParamTextlist.Count){
                             $descriptionString += " and $($ParamTextlist[$i])"
-                            $deatiledDescriptionString += " and $($ParamTextlist[$i]) are required parameters"
+                            $deatiledDescriptionString += " and $($ParamTextlist[$i]) are required parameters."
 
                         } else {
                             $descriptionString += " $($ParamTextlist[$i]),"
@@ -229,9 +229,9 @@ foreach ($item in $list) {
         $functionOutputMatch = $functionContent | Select-String -Pattern $outputRegex -AllMatches
         if ($functionOutputMatch){
             $functionOutputModel = ($functionOutputMatch.Matches.Value).Replace('.Models.I', '.Models.')
-            $functionOutputModel
+            # $functionOutputModel
 
-            Write-Warning "$($item.functionName) model: $functionOutputModel"
+            # Write-Warning "$($item.functionName) model: $functionOutputModel"
 
 
             if ($functionOutputModel -match ".Models"){

--- a/Tools/Build-SdkExamples.ps1
+++ b/Tools/Build-SdkExamples.ps1
@@ -182,7 +182,22 @@ foreach ($item in $list) {
         switch ($set) {
             'List' {
                 $descriptionString = "List $($item.functionBaseType)s"
-                $deatiledDescriptionString = "This function will return a list of all $($item.functionBaseType)s"
+                $deatiledDescriptionString = "This function will return a list of all $($item.functionBaseType)s."
+                $optionalParams = ($paramInfo.$Set | Where-Object {$_.parameterMandatory -eq $false}).parameterName
+                if ($optionalParams.count -eq 1){
+                    $deatiledDescriptionString += " $optionalParams is an optional parameter."
+                } else {
+                    for ($i = 0; $i -lt $optionalParams.Count; $i++) {
+                        <# Action that will repeat until the condition is met #>
+                        if ($i+1 -eq $optionalParams.Count){
+                            $deatiledDescriptionString += " and $($optionalParams[$i]) are optional parameters."
+
+                        } else {
+                            $deatiledDescriptionString += " $($optionalParams[$i]),"
+                        }
+                    }
+
+                }
             }
             Default {
                 # an vs a


### PR DESCRIPTION
## Issues
* [CUT-3982](https://jumpcloud.atlassian.net/browse/CUT-3982) - Auto-Generate SDK Examples for each function

## What does this solve?

This contains a new tool to generate example documentation for each SDK function after SDK generation. This is a first pass at getting each of our SDK functions better documented. This release focuses on just generating example descriptions and parameter lists for each generated function. 

Take `Get-JcSdkApplication` for example. 

the Generated `docs/Get-JcSdkApplication.md` file for this release would look like this:

```md
### Example 1: List Applications
`PS C:\> Get-JcSdkApplication -Fields:(<string>) -Filter:(<string[]>) -Sort:(<string>)`

----                       ----------
Active                     Boolean
Beta                       Boolean
Color                      String
Config                     JumpCloud.SDK.V1.Models.ApplicationConfig
Created                    String
DatabaseAttributes         JumpCloud.SDK.V1.Models.ApplicationDatabaseAttributesItem[]
Description                String
DisplayLabel               String
DisplayName                String
Id                         String
LearnMore                  String
LogoColor                  String
LogoUrl                    String
Name                       String
Organization               String
SsoBeta                    Boolean
SsoHidden                  Boolean
SsoIdpCertExpirationAt     Datetime
SsoIdpCertificateUpdatedAt Datetime
SsoIdpPrivateKeyUpdatedAt  Datetime
SsoJit                     Boolean
SsoSpCertificateUpdatedAt  Datetime
SsoType                    String
SsoUrl                     String

This function will return a list of all Applications. Fields, Filter, and Sort are optional parameters.

### Example 2: Get an Application by Id
`PS C:\> Get-JcSdkApplication -Id:(<string>)`

----                       ----------
Active                     Boolean
Beta                       Boolean
Color                      String
Config                     JumpCloud.SDK.V1.Models.ApplicationConfig
Created                    String
DatabaseAttributes         JumpCloud.SDK.V1.Models.ApplicationDatabaseAttributesItem[]
Description                String
DisplayLabel               String
DisplayName                String
Id                         String
LearnMore                  String
LogoColor                  String
LogoUrl                    String
Name                       String
Organization               String
SsoBeta                    Boolean
SsoHidden                  Boolean
SsoIdpCertExpirationAt     Datetime
SsoIdpCertificateUpdatedAt Datetime
SsoIdpPrivateKeyUpdatedAt  Datetime
SsoJit                     Boolean
SsoSpCertificateUpdatedAt  Datetime
SsoType                    String
SsoUrl                     String

This function will Get an Application by Id. Id is a required parameter.

```

For each parameter set (List and Get), the function from this release will update the autorest auto-generated .md Examples 1 & 2 with a basic example title description and valid parameter list for each type set.

Only system types are included for each parameter, text fields per parameter are not mapped yet. Output is something that we could potentially generate in future work along with description. 

The ultimate aim here would be to delete the example .md files before generation and generate/validate our SDK documentation on each build - this would ensure that our documentation is valid for each new release. 

## Is there anything particularly tricky?

Documentation should be accurate but it's not being tested against anything, future work should be done to map values to functions so we can test our function examples. 

## How should this be tested?

Not really, in order to test this, run the `Build-SdkExamples.ps1` file for one/ all of the SDK modules and click through the git diff files changed in `/docs` for each module. 

## Screenshots



[CUT-3982]: https://jumpcloud.atlassian.net/browse/CUT-3982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ