### PR TITLE
CI Release Individual Updates

### DIFF
--- a/.github/workflows/jcapi-powershell-ci.yml
+++ b/.github/workflows/jcapi-powershell-ci.yml
@@ -356,14 +356,35 @@ jobs:
         shell: pwsh
         run: |
           Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V2.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
-      - uses: actions/download-artifact@v4
-        with:
-          name: build-JumpCloud.SDK.V1
-          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
-      - name: Unzip V1 module for V2 Tests
+      - name: Download JumpCloud.SDK.V1 from PSGallery
         shell: pwsh
         run: |
-          Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
+          # Define the destination path for the module files
+          $parentDir = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell"
+          $moduleName = "JumpCloud.SDK.V1"
+          $moduleDir = Join-Path $parentDir $moduleName
+
+          # Save the module from the gallery. This command creates a nested version folder,
+          Write-Host "Downloading '$moduleName' from PSGallery to '$parentDir'..."
+          Save-Module -Name $moduleName -Repository PSGallery -Path $parentDir -Force
+
+          # Get the path to the version-specific folder that was just created
+          $versionedDir = Get-ChildItem -Path $moduleDir -Directory | Select-Object -First 1
+          if (-not $versionedDir) {
+            Write-Error "Failed to find downloaded module version directory inside '$moduleDir'."
+            exit 1
+          }
+          Write-Host "Found module version directory at '$($versionedDir.FullName)'."
+
+          # Move all contents from the versioned folder up into the main module directory
+          Write-Host "Moving module contents to the expected path: '$moduleDir'..."
+          Move-Item -Path (Join-Path $versionedDir.FullName "*") -Destination $moduleDir -Force
+
+          # Remove the now-empty versioned folder to clean up
+          Write-Host "Cleaning up empty directory: $($versionedDir.FullName)"
+          Remove-Item -Path $versionedDir.FullName -Force
+
+          Write-Host "Module '$moduleName' is now correctly placed at '$moduleDir'."
       - name: Test JumpCloud.SDK.V2
         shell: pwsh
         env:
@@ -428,14 +449,35 @@ jobs:
         shell: pwsh
         run: |
           Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V2.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
-      - uses: actions/download-artifact@v4
-        with:
-          name: build-JumpCloud.SDK.V1
-          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
-      - name: Unzip V1 module for V2 Tests
+      - name: Download JumpCloud.SDK.V1 from PSGallery
         shell: pwsh
         run: |
-          Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
+          # Define the destination path for the module files
+          $parentDir = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell"
+          $moduleName = "JumpCloud.SDK.V1"
+          $moduleDir = Join-Path $parentDir $moduleName
+
+          # Save the module from the gallery. This command creates a nested version folder,
+          Write-Host "Downloading '$moduleName' from PSGallery to '$parentDir'..."
+          Save-Module -Name $moduleName -Repository PSGallery -Path $parentDir -Force
+
+          # Get the path to the version-specific folder that was just created
+          $versionedDir = Get-ChildItem -Path $moduleDir -Directory | Select-Object -First 1
+          if (-not $versionedDir) {
+            Write-Error "Failed to find downloaded module version directory inside '$moduleDir'."
+            exit 1
+          }
+          Write-Host "Found module version directory at '$($versionedDir.FullName)'."
+
+          # Move all contents from the versioned folder up into the main module directory
+          Write-Host "Moving module contents to the expected path: '$moduleDir'..."
+          Move-Item -Path (Join-Path $versionedDir.FullName "*") -Destination $moduleDir -Force
+
+          # Remove the now-empty versioned folder to clean up
+          Write-Host "Cleaning up empty directory: $($versionedDir.FullName)"
+          Remove-Item -Path $versionedDir.FullName -Force
+
+          Write-Host "Module '$moduleName' is now correctly placed at '$moduleDir'."
       - name: Test MTP JumpCloud.SDK.V2
         shell: pwsh
         env:

--- a/.github/workflows/jcapi-powershell-ci.yml
+++ b/.github/workflows/jcapi-powershell-ci.yml
@@ -1,327 +1,448 @@
 name: PowerShell SDK CI
 
 on:
-    pull_request:
-      branches:
-        - "master"
+  pull_request:
+    branches:
+      - master
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-    cancel-in-progress: true
-jobs:
-    Filter-Branch:
-      runs-on: ubuntu-latest
-      if: contains(github.event.pull_request.labels.*.name, 'SDK')
-      steps:
-        - run: echo "Building SDKs"
-    Check-PR-Labels:
-      needs: ['Filter-Branch']
-      runs-on: ubuntu-latest
-      outputs:
-        RELEASE_TYPE: ${{ steps.validate.outputs.RELEASE_TYPE }}
-      steps:
-        - name: Validate-PR-Version-Labels
-          id: validate
-          shell: pwsh
-          run: |
-            $PR_LABEL_LIST=$(curl -s "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" | jq -r '.[].name')
-            if ("SDK" -in $PR_LABEL_LIST) {
-                write-host "Starting Build for PowerShell SDK Release"
-            }
-            # validate type from label list:
-            $types = @('major', 'minor', 'patch', 'manual')
-            $typeCount = 0
-            foreach ($item in $PR_LABEL_LIST) {
-                if ($item -in $types) {
-                    write-host "$item"
-                    $typeCount += 1
-                    $RELEASE_TYPE = $item
-                }
-            }
-            if ($typeCount -eq 1) {
-                echo "RELEASE_TYPE=$RELEASE_TYPE" >> $env:GITHUB_OUTPUT
-            } else {
-                throw "Multiple or invalid release types were found on PR"
-                exit 1
-            }
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    Setup-Build-Dependancies:
-        needs: ['Filter-Branch']
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        steps:
-            - uses: actions/checkout@v4
-            - name: Setup PowerShell Module Cache
-              id: cacher
-              uses: actions/cache@v3
-              with:
-                path: "/home/runner/.local/share/powershell/Modules/"
-                key: PS-Dependancies
-            - name: Install dependencies
-              if: steps.cacher.outputs.cache-hit != 'true'
-              shell: pwsh
-              env:
-                PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
-                PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
-                PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
-              run: |
-                Set-PSRepository PSGallery -InstallationPolicy Trusted
-                If (!(Get-PackageProvider -Name:('NuGet') -ListAvailable -ErrorAction:('SilentlyContinue'))) {
-                    Write-Host ('[status]Installing package provider NuGet');
-                    Install-PackageProvider -Name:('NuGet') -Scope:('CurrentUser') -Force
-                }
-                $PSDependencies = @{
-                    'AWS.Tools.CodeArtifact' = @{Repository = 'PSGallery'; RequiredVersion = '4.1.14.0' }
-                    'AWS.Tools.Common'       = @{Repository = 'PSGallery'; RequiredVersion = '4.1.14.0' }
-                    'BuildHelpers'           = @{Repository = 'PSGallery'; RequiredVersion = '2.0.15'}
-                    'Pester'                 = @{Repository = 'PSGallery'; RequiredVersion = '5.3.1'}
-                    'powershell-yaml'        = @{Repository = 'PSGallery'; RequiredVersion = '0.4.2'}
-                    'PowerShellGet'          = @{Repository = 'PSGallery'; RequiredVersion = '3.0.12-beta'}
-                    'PSScriptAnalyzer'       = @{Repository = 'PSGallery'; RequiredVersion = '1.19.1'}
-                }
-                foreach ($RequiredModule in $PSDependencies.Keys) {
-                    If ([System.String]::IsNullOrEmpty((Get-InstalledModule | Where-Object { $_.Name -eq $RequiredModule }))) {
-                        Write-Host("[status]Installing module: '$RequiredModule'; version: $($PSDependencies[$RequiredModule].RequiredVersion) from $($PSDependencies[$RequiredModule].Repository)")
-                        Install-Module -Name $RequiredModule -Repository:($($PSDependencies[$RequiredModule].Repository)) -RequiredVersion:($($PSDependencies[$RequiredModule].RequiredVersion)) -AllowPrerelease -Force
-                    }
-                }
-    Validate-SDK-Module:
-      needs: ["Setup-Build-Dependancies"]
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/cache@v3
-          with:
-            path: "/home/runner/.local/share/powershell/Modules/"
-            key: PS-Dependancies
-        - uses: actions/checkout@v4
-        - name: Validate SDK Module
-          id: validate
-          shell: pwsh
-          run: |
-            Install-Module -Name Pester
-            Invoke-Pester -Path /home/runner/work/jcapi-powershell/jcapi-powershell/Tools/ModuleValidation.Tests.ps1
-    Build-SDK:
-        needs: ["Setup-Build-Dependancies"]
-        runs-on: ubuntu-latest
-        timeout-minutes: 70
-        strategy:
-            fail-fast: false
-            matrix:
-                SDKName: ['JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2']
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/cache@v3
-              with:
-                path: "/home/runner/.local/share/powershell/Modules/"
-                key: PS-Dependancies
-            - name: Build ${{ matrix.SDKName }}
-              shell: pwsh
-              run: |
-                ./BuildAutoRest -SDKName:("${{ matrix.SDKName }}")
-            - name: Pack ${{ matrix.SDKName }} Module
-              shell: pwsh
-              run: |
-                $ModuleName = "${{ matrix.SDKName }}"
-                $Psd1 = Import-PowerShellDataFile -Path:("/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.psd1")
-                $nupkgFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/bin/nupkg"
-                $csprojFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.csproj"
-                $nuspecFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.nuspec"
-                $BuildVersion = $Psd1.ModuleVersion
-                $nuspecContent = [System.Xml.XmlDocument](Get-Content -Path:($nuspecFilePath))
-                $nuspecContent.package.metadata.version = $BuildVersion
-                $nuspecContent.save($nuspecFilePath)
-                dotnet pack $csprojFilePath --output $nupkgFilePath --configuration=$ModuleName
-            - name: Zip ${{ matrix.SDKName }} Module
-              shell: pwsh
-              run: |
-                # zip contents for artifact
-                Compress-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/${{ matrix.SDKName }} -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/${{ matrix.SDKName }}.zip -CompressionLevel Optimal -Force
-            - uses: ./.github/actions/upload-secure-artifact
-              with:
-                name: build-${{ matrix.SDKName }}
-                path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/${{ matrix.SDKName }}.zip
-                retention-days: 1
-    Test-SDK:
-        needs: ["Setup-Build-Dependancies", "Build-SDK"]
-        runs-on: ubuntu-latest
-        timeout-minutes: 70
-        strategy:
-            fail-fast: false
-            matrix:
-                SDKName: ['JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2']
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/cache@v3
-              with:
-                path: "/home/runner/.local/share/powershell/Modules/"
-                key: PS-Dependancies
-            - uses: actions/download-artifact@v4
-              with:
-                name: build-${{ matrix.SDKName }}
-                path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
-            - name: Unzip ${{ matrix.SDKName }} module
-              shell: pwsh
-              run: |
-                Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/${{ matrix.SDKName }}.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
-            - uses: actions/download-artifact@v4
-              with:
-                name: build-JumpCloud.SDK.V1
-                path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
-              if: matrix.SDKName == 'JumpCloud.SDK.V2'
-            - name: Unzip V1 module for V2 Tests
-              shell: pwsh
-              run: |
-                Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
-              if: matrix.SDKName == 'JumpCloud.SDK.V2'
-            - name: Test ${{ matrix.SDKName }}
-              shell: pwsh
-              env:
-                PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
-                PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
-                PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
-                PESTER_PROVIDERID: ${{ secrets.PESTER_PROVIDERID }}
-              run: |
-                $ErrorActionnPreference = 'Stop'
-                ./Test-Module.ps1 -JCApiKey:($env:PESTER_APIKEY) -JCOrgId:($env:PESTER_ORGID) -JCApiKeyMTP:($env:PESTER_MSP_APIKEY) -JCProviderId:($env:PESTER_PROVIDERID) -ExcludeTagList:("MTP") -IncludeTagList:("*") -testModulePath:("./SDKs/PowerShell/${{ matrix.SDKName }}/test-module.ps1")
-    Test-SDK-MTP:
-        needs: ["Setup-Build-Dependancies", "Build-SDK"]
-        runs-on: ubuntu-latest
-        timeout-minutes: 70
-        strategy:
-            fail-fast: false
-            matrix:
-                SDKName: ['JumpCloud.SDK.V1', 'JumpCloud.SDK.V2']
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/cache@v3
-              with:
-                path: "/home/runner/.local/share/powershell/Modules/"
-                key: PS-Dependancies
-            - uses: actions/download-artifact@v4
-              with:
-                name: build-${{ matrix.SDKName }}
-                path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
-            - name: Unzip ${{ matrix.SDKName }} module
-              shell: pwsh
-              run: |
-                Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/${{ matrix.SDKName }}.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
-            - uses: actions/download-artifact@v4
-              with:
-                name: build-JumpCloud.SDK.V1
-                path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
-              if: matrix.SDKName == 'JumpCloud.SDK.V2'
-            - name: Unzip V1 module for V2 Tests
-              shell: pwsh
-              run: |
-                Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
-              if: matrix.SDKName == 'JumpCloud.SDK.V2'
-            - name: Test MTP ${{ matrix.SDKName }}
-              shell: pwsh
-              env:
-                PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
-                PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
-                PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
-                PESTER_PROVIDERID: ${{ secrets.PESTER_PROVIDERID }}
-              run: |
-                $ErrorActionnPreference = 'Stop'
-                ./Test-Module.ps1 -JCApiKey:($env:PESTER_APIKEY) -JCOrgId:($env:PESTER_ORGID) -JCApiKeyMTP:($env:PESTER_MSP_APIKEY) -JCProviderId:($env:PESTER_PROVIDERID) -ExcludeTagList:("None") -IncludeTagList:("MTP") -testModulePath:("./SDKs/PowerShell/${{ matrix.SDKName }}/test-module.ps1")
-    # Invoke-Pester:
-    #     needs: ["Setup-Build-Dependancies", "Build-SDK"]
-    #     runs-on: ubuntu-latest
-    #     timeout-minutes: 70
-    #     steps:
-    #       - uses: actions/checkout@v4
-    #       - name: Checkout Support Repo
-    #         uses: actions/checkout@v4
-    #         with:
-    #           repository: TheJumpCloud/support
-    #           path: './support'
-    #       - uses: actions/cache@v3
-    #         with:
-    #           path: "/home/runner/.local/share/powershell/Modules/"
-    #           key: PS-Dependancies
-    #       - uses: actions/download-artifact@v4
-    #         with:
-    #           name: build-JumpCloud.SDK.DirectoryInsights
-    #           path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
-    #       - uses: actions/download-artifact@v4
-    #         with:
-    #           name: build-JumpCloud.SDK.V1
-    #           path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
-    #       - uses: actions/download-artifact@v4
-    #         with:
-    #           name: build-JumpCloud.SDK.V2
-    #           path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
-    #       - name: Unzip artifacts
-    #         shell: pwsh
-    #         run: |
-    #           Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
-    #           Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
-    #           Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V2.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
-    #       - name: Invoke Pester
-    #         shell: pwsh
-    #         env:
-    #           PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
-    #           PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
-    #           PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
-    #           PESTER_PROVIDERID: ${{ secrets.PESTER_PROVIDERID }}
-    #         run: |
-    #           $ErrorActionPreference = 'stop'
-    #           # Import all the SDKs
-    #           # register PS Repo local
-    #           Register-PSRepository -Name SDKs -SourceLocation "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/"
-    #           $sdks = @('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2')
-    #           foreach ($sdk in $sdks){
-    #             Publish-Module -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$sdk/ -Repository SDKs
-    #             Install-Module -Repository SDKs -Name $sdk -Force
-    #           }
-    #           # list JumpCloud Modules Imported
-    #           Get-Module -Name Jumpcloud*
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
-    #           # Get functions from module:
-    #           $pathList = @('Private', 'Public')
-    #           # Get matching functions
-    #           $functions = $pathList | ForEach-Object {
-    #               Get-ChildItem "./support/PowerShell/JumpCloud Module/$($_)/*.ps1" -Recurse
-    #           }
-    #           # Get Tags with SDK functions:
-    #           $testTags = @()
-    #           # For each function file
-    #           foreach ($file in $functions) {
-    #               $regex = [regex]'jcsdk'
-    #               if (Select-String -path $file.FullName -Pattern $regex){
-    #                   # If 'jcsdk' is used in the function file continue
-    #                   # get test file
-    #                   $testFile = ($file.FullName -replace "JumpCloud Module", "JumpCloud Module/Tests") -replace ".ps1", ".Tests.ps1"
-    #                   $tagRegex = [regex]'-Tag:\(.(\w+).\)'
-    #                   $testTag = Select-String -path $testFile -Pattern $tagRegex
-    #                   # "$test"
-    #                   if ($testTag.matches) {
-    #                       # If tag found in test file add to testTags list:
-    #                       $testTags += $testTag.matches.Groups[1].Value
-    #                   }
-    #               }
-    #           }
-    #           # return found tags
-    #           $tags = ($testTags | Select-Object -Unique)
-    #           # Manually add tags that we can't automatically add with script above:
-    #           # At this time only associations need to be added:
-    #           $tags += 'JCAssociation'
-    #           # setup org:
-    #           $variables = . "./support/PowerShell/JumpCloud Module/Tests/SetupOrg.ps1" -JumpCloudApiKey "$env:PESTER_APIKEY" -JumpCloudApiKeyMsp "$env:PESTER_MSP_APIKEY"
-    #           Write-Host "[status] Setting Env Variables for tests"
-    #           $variables | Foreach-Object {
-    #               if ($_.Name) {
-    #                   Set-Variable -Name $_.Name -Value $_.Value -Scope Global
-    #               }
-    #           }
-    #           # remove email users if they exitst
-    #           $emailUsers = Search-JCSDKUser -Searchfilter @{searchTerm = 'importcsvuser';fields = @('email')}
-    #           if ($emailUsers){
-    #             $emailUsers | ForEach-Object { Remove-JcSdkUser -id $_.id }
-    #           }
-    #           Import-Module "./support/PowerShell/JumpCloud Module/JumpCloud.psd1"
-    #           # disable parallel tests:
-    #           Set-JCSettingsFile -parallelOverride $true
-    #           # Invoke Pester
-    #           . "./support/PowerShell/JumpCloud Module/Tests/InvokePester.ps1" -JumpCloudApiKey $env:PESTER_APIKEY -ExcludeTagList:('MSP', 'JCDeployment', 'JCOnline') -IncludeTagList:($tags) -RequiredModulesRepo:('PSGallery')
+jobs:
+  Filter-Branch:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'SDK')
+    steps:
+      - run: echo "Building SDKs"
+
+  Check-PR-Labels:
+    needs: ['Filter-Branch']
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_TYPE: ${{ steps.set_labels.outputs.RELEASE_TYPE }}
+      V1: ${{ steps.set_labels.outputs.V1 }}
+      V2: ${{ steps.set_labels.outputs.V2 }}
+      DIRECTORYINSIGHTS: ${{ steps.set_labels.outputs.DIRECTORYINSIGHTS }}
+    steps:
+      - name: Set Environment Variables from PR Labels
+        id: set_labels
+        shell: pwsh
+        run: |
+          # Fetch and natively parse the JSON list of labels from the PR
+          $jsonResponse = curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" `
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels"
+          $PR_LABEL_LIST = ($jsonResponse | ConvertFrom-Json).name
+          Write-Host "Found labels on PR: $($PR_LABEL_LIST -join ', ')"
+
+          # --- Set Release Type Environment Variable using a loop ---
+          $validReleaseTypes = @('major', 'minor', 'patch', 'manual')
+          $validSdkTypes = @('v1', 'v2', 'DirectoryInsights')
+          $foundReleaseType = ''
+          $typeCount = 0
+          $sdkTypeCount = 0
+
+          # Loop through the labels found on the PR
+          foreach ($label in $PR_LABEL_LIST) {
+              # Check if the current label is a valid release type
+              if ($label -in $validReleaseTypes) {
+                  $typeCount++
+                  $foundReleaseType = $label
+              }
+              # Check if the current label is a valid SDK type
+              if ($label -in $validSdkTypes) {
+                  $sdkTypeCount++
+              }
+          }
+
+          # Validate that exactly one release type was found
+          if ($typeCount -eq 1) {
+              Write-Host "Release Type set to: $foundReleaseType"
+              echo "RELEASE_TYPE=$foundReleaseType" >> $env:GITHUB_OUTPUT
+          } else {
+              throw "Error: Expected exactly one release type label (major, minor, patch, manual), but found $typeCount."
+          }
+
+          # Validate that only one SDK type was found
+          if ($sdkTypeCount -gt 1) {
+              throw "Error: Expected only one SDK type label (v1, v2, DirectoryInsights), but found $sdkTypeCount."
+          }
+
+          # --- Set Module Environment Variables ---
+          if ('v1' -in $PR_LABEL_LIST) {
+            Write-Host "Module label 'v1' found"
+            echo "v1=true" >> $env:GITHUB_OUTPUT
+          }
+          if ('v2' -in $PR_LABEL_LIST) {
+            Write-Host "Module label 'v2' found"
+            echo "v2=true" >> $env:GITHUB_OUTPUT
+          }
+          if ('DirectoryInsights' -in $PR_LABEL_LIST) {
+            Write-Host "Module label 'DirectoryInsights' found"
+            echo "directoryinsights=true" >> $env:GITHUB_OUTPUT
+          }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  Setup-Build-Dependancies:
+    needs: ['Filter-Branch']
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PowerShell Module Cache
+        id: cacher
+        uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - name: Install dependencies
+        if: steps.cacher.outputs.cache-hit != 'true'
+        shell: pwsh
+        env:
+          PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
+          PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
+          PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          If (!(Get-PackageProvider -Name:('NuGet') -ListAvailable -ErrorAction:('SilentlyContinue'))) {
+              Write-Host ('[status]Installing package provider NuGet');
+              Install-PackageProvider -Name:('NuGet') -Scope:('CurrentUser') -Force
+          }
+          $PSDependencies = @{
+              'AWS.Tools.CodeArtifact' = @{Repository = 'PSGallery'; RequiredVersion = '4.1.14.0' }
+              'AWS.Tools.Common'       = @{Repository = 'PSGallery'; RequiredVersion = '4.1.14.0' }
+              'BuildHelpers'           = @{Repository = 'PSGallery'; RequiredVersion = '2.0.15'}
+              'Pester'                 = @{Repository = 'PSGallery'; RequiredVersion = '5.3.1'}
+              'powershell-yaml'        = @{Repository = 'PSGallery'; RequiredVersion = '0.4.2'}
+              'PowerShellGet'          = @{Repository = 'PSGallery'; RequiredVersion = '3.0.12-beta'}
+              'PSScriptAnalyzer'       = @{Repository = 'PSGallery'; RequiredVersion = '1.19.1'}
+          }
+          foreach ($RequiredModule in $PSDependencies.Keys) {
+              If ([System.String]::IsNullOrEmpty((Get-InstalledModule | Where-Object { $_.Name -eq $RequiredModule }))) {
+                  Write-Host("[status]Installing module: '$RequiredModule'; version: $($PSDependencies[$RequiredModule].RequiredVersion) from $($PSDependencies[$RequiredModule].Repository)")
+                  Install-Module -Name $RequiredModule -Repository:($($PSDependencies[$RequiredModule].Repository)) -RequiredVersion:($($PSDependencies[$RequiredModule].RequiredVersion)) -AllowPrerelease -Force
+              }
+          }
+
+  Validate-SDK-Module:
+    needs: ["Setup-Build-Dependancies", "Check-PR-Labels"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - uses: actions/checkout@v4
+      - name: Validate SDK Module
+        id: validate
+        shell: pwsh
+        env:
+          v1: ${{ needs.Check-PR-Labels.outputs.v1 }}
+          v2: ${{ needs.Check-PR-Labels.outputs.v2 }}
+          directoryinsights: ${{ needs.Check-PR-Labels.outputs.directoryinsights }}
+          RELEASE_TYPE: ${{ needs.Check-PR-Labels.outputs.RELEASE_TYPE }}
+        run: |
+          # Construct the PR_LABELS variable for the Pester test script
+          $prLabels = @()
+          if ($env:v1) { $prLabels += 'v1' }
+          if ($env:v2) { $prLabels += 'v2' }
+          if ($env:directoryinsights) { $prLabels += 'DirectoryInsights' }
+          if ($env:RELEASE_TYPE) { $prLabels += $env:RELEASE_TYPE }
+          $prLabels += 'sdk'
+          $env:PR_LABELS = $prLabels -join ','
+
+          Write-Host "Passing the following labels to Pester: $env:PR_LABELS"
+          Install-Module -Name Pester
+          Invoke-Pester -Path /home/runner/work/jcapi-powershell/jcapi-powershell/Tools/ModuleValidation.Tests.ps1
+
+  ## ----------------------------------------------------------------
+  ## Build Jobs
+  ## ----------------------------------------------------------------
+
+  Build-SDK-DI:
+    needs: ["Setup-Build-Dependancies", "Check-PR-Labels", "Validate-SDK-Module"]
+    if: contains(github.event.pull_request.labels.*.name, 'DirectoryInsights')
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - name: Build JumpCloud.SDK.DirectoryInsights
+        shell: pwsh
+        run: |
+          ./BuildAutoRest -SDKName:("JumpCloud.SDK.DirectoryInsights") -VersionType "${{ needs.Check-PR-Labels.outputs.RELEASE_TYPE }}"
+      - name: Pack JumpCloud.SDK.DirectoryInsights Module
+        shell: pwsh
+        run: |
+          $ModuleName = "JumpCloud.SDK.DirectoryInsights"
+          $Psd1 = Import-PowerShellDataFile -Path:("/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.psd1")
+          $nupkgFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/bin/nupkg"
+          $csprojFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.csproj"
+          $nuspecFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.nuspec"
+          $BuildVersion = $Psd1.ModuleVersion
+          $nuspecContent = [System.Xml.XmlDocument](Get-Content -Path:($nuspecFilePath))
+          $nuspecContent.package.metadata.version = $BuildVersion
+          $nuspecContent.save($nuspecFilePath)
+          dotnet pack $csprojFilePath --output $nupkgFilePath --configuration=$ModuleName
+      - name: Zip JumpCloud.SDK.DirectoryInsights Module
+        shell: pwsh
+        run: |
+          Compress-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights.zip -CompressionLevel Optimal -Force
+      - uses: ./.github/actions/upload-secure-artifact
+        with:
+          name: build-JumpCloud.SDK.DirectoryInsights
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights.zip
+          retention-days: 1
+
+  Build-SDK-V1:
+    needs: ["Setup-Build-Dependancies", "Check-PR-Labels", "Validate-SDK-Module"]
+    if: contains(github.event.pull_request.labels.*.name, 'v1') || contains(github.event.pull_request.labels.*.name, 'v2')
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - name: Build JumpCloud.SDK.V1
+        shell: pwsh
+        run: |
+          ./BuildAutoRest -SDKName:("JumpCloud.SDK.V1") -VersionType "${{ needs.Check-PR-Labels.outputs.RELEASE_TYPE }}"
+      - name: Pack JumpCloud.SDK.V1 Module
+        shell: pwsh
+        run: |
+          $ModuleName = "JumpCloud.SDK.V1"
+          $Psd1 = Import-PowerShellDataFile -Path:("/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.psd1")
+          $nupkgFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/bin/nupkg"
+          $csprojFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.csproj"
+          $nuspecFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.nuspec"
+          $BuildVersion = $Psd1.ModuleVersion
+          $nuspecContent = [System.Xml.XmlDocument](Get-Content -Path:($nuspecFilePath))
+          $nuspecContent.package.metadata.version = $BuildVersion
+          $nuspecContent.save($nuspecFilePath)
+          dotnet pack $csprojFilePath --output $nupkgFilePath --configuration=$ModuleName
+      - name: Zip JumpCloud.SDK.V1 Module
+        shell: pwsh
+        run: |
+          Compress-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1 -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -CompressionLevel Optimal -Force
+      - uses: ./.github/actions/upload-secure-artifact
+        with:
+          name: build-JumpCloud.SDK.V1
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip
+          retention-days: 1
+
+  Build-SDK-V2:
+    needs: ["Setup-Build-Dependancies" , "Check-PR-Labels" , "Validate-SDK-Module"]
+    if: contains(github.event.pull_request.labels.*.name, 'v2')
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - name: Build JumpCloud.SDK.V2
+        shell: pwsh
+        run: |
+          ./BuildAutoRest -SDKName:("JumpCloud.SDK.V2") -VersionType "${{ needs.Check-PR-Labels.outputs.RELEASE_TYPE }}"
+      - name: Pack JumpCloud.SDK.V2 Module
+        shell: pwsh
+        run: |
+          $ModuleName = "JumpCloud.SDK.V2"
+          $Psd1 = Import-PowerShellDataFile -Path:("/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.psd1")
+          $nupkgFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/bin/nupkg"
+          $csprojFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.csproj"
+          $nuspecFilePath = "/home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/$ModuleName/$ModuleName.nuspec"
+          $BuildVersion = $Psd1.ModuleVersion
+          $nuspecContent = [System.Xml.XmlDocument](Get-Content -Path:($nuspecFilePath))
+          $nuspecContent.package.metadata.version = $BuildVersion
+          $nuspecContent.save($nuspecFilePath)
+          dotnet pack $csprojFilePath --output $nupkgFilePath --configuration=$ModuleName
+      - name: Zip JumpCloud.SDK.V2 Module
+        shell: pwsh
+        run: |
+          Compress-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V2 -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V2.zip -CompressionLevel Optimal -Force
+      - uses: ./.github/actions/upload-secure-artifact
+        with:
+          name: build-JumpCloud.SDK.V2
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V2.zip
+          retention-days: 1
+
+  ## ----------------------------------------------------------------
+  ## Test Jobs
+  ## ----------------------------------------------------------------
+
+  Test-SDK-DI:
+    needs: ["Build-SDK-DI", "Check-PR-Labels"]
+    if: contains(github.event.pull_request.labels.*.name, 'DirectoryInsights')
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-JumpCloud.SDK.DirectoryInsights
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
+      - name: Unzip JumpCloud.SDK.DirectoryInsights module
+        shell: pwsh
+        run: |
+          Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
+      - name: Test JumpCloud.SDK.DirectoryInsights
+        shell: pwsh
+        env:
+          PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
+          PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
+          PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
+          PESTER_PROVIDERID: ${{ secrets.PESTER_PROVIDERID }}
+        run: |
+          $ErrorActionnPreference = 'Stop'
+          ./Test-Module.ps1 -JCApiKey:($env:PESTER_APIKEY) -JCOrgId:($env:PESTER_ORGID) -JCApiKeyMTP:($env:PESTER_MSP_APIKEY) -JCProviderId:($env:PESTER_PROVIDERID) -ExcludeTagList:("MTP") -IncludeTagList:("*") -testModulePath:("./SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights/test-module.ps1")
+
+  Test-SDK-V1:
+    needs: ["Build-SDK-V1", "Check-PR-Labels"]
+    if: contains(github.event.pull_request.labels.*.name, 'v1') || contains(github.event.pull_request.labels.*.name, 'v2')
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-JumpCloud.SDK.V1
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
+      - name: Unzip JumpCloud.SDK.V1 module
+        shell: pwsh
+        run: |
+          Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
+      - name: Test JumpCloud.SDK.V1
+        shell: pwsh
+        env:
+          PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
+          PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
+          PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
+          PESTER_PROVIDERID: ${{ secrets.PESTER_PROVIDERID }}
+        run: |
+          $ErrorActionnPreference = 'Stop'
+          ./Test-Module.ps1 -JCApiKey:($env:PESTER_APIKEY) -JCOrgId:($env:PESTER_ORGID) -JCApiKeyMTP:($env:PESTER_MSP_APIKEY) -JCProviderId:($env:PESTER_PROVIDERID) -ExcludeTagList:("MTP") -IncludeTagList:("*") -testModulePath:("./SDKs/PowerShell/JumpCloud.SDK.V1/test-module.ps1")
+
+  Test-SDK-V2:
+    needs: ["Build-SDK-V1", "Build-SDK-V2", "Check-PR-Labels"]
+    if: contains(github.event.pull_request.labels.*.name, 'v2')
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-JumpCloud.SDK.V2
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
+      - name: Unzip JumpCloud.SDK.V2 module
+        shell: pwsh
+        run: |
+          Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V2.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-JumpCloud.SDK.V1
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
+      - name: Unzip V1 module for V2 Tests
+        shell: pwsh
+        run: |
+          Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
+      - name: Test JumpCloud.SDK.V2
+        shell: pwsh
+        env:
+          PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
+          PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
+          PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
+          PESTER_PROVIDERID: ${{ secrets.PESTER_PROVIDERID }}
+        run: |
+          $ErrorActionnPreference = 'Stop'
+          ./Test-Module.ps1 -JCApiKey:($env:PESTER_APIKEY) -JCOrgId:($env:PESTER_ORGID) -JCApiKeyMTP:($env:PESTER_MSP_APIKEY) -JCProviderId:($env:PESTER_PROVIDERID) -ExcludeTagList:("MTP") -IncludeTagList:("*") -testModulePath:("./SDKs/PowerShell/JumpCloud.SDK.V2/test-module.ps1")
+
+  ## ----------------------------------------------------------------
+  ## MTP Test Jobs
+  ## ----------------------------------------------------------------
+
+  Test-SDK-MTP-V1:
+    needs: ["Build-SDK-V1", "Check-PR-Labels"]
+    if: contains(github.event.pull_request.labels.*.name, 'v1') || contains(github.event.pull_request.labels.*.name, 'v2')
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-JumpCloud.SDK.V1
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
+      - name: Unzip JumpCloud.SDK.V1 module
+        shell: pwsh
+        run: |
+          Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
+      - name: Test MTP JumpCloud.SDK.V1
+        shell: pwsh
+        env:
+          PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
+          PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
+          PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
+          PESTER_PROVIDERID: ${{ secrets.PESTER_PROVIDERID }}
+        run: |
+          $ErrorActionnPreference = 'Stop'
+          ./Test-Module.ps1 -JCApiKey:($env:PESTER_APIKEY) -JCOrgId:($env:PESTER_ORGID) -JCApiKeyMTP:($env:PESTER_MSP_APIKEY) -JCProviderId:($env:PESTER_PROVIDERID) -ExcludeTagList:("None") -IncludeTagList:("MTP") -testModulePath:("./SDKs/PowerShell/JumpCloud.SDK.V1/test-module.ps1")
+
+  Test-SDK-MTP-V2:
+    needs: ["Build-SDK-V1", "Build-SDK-V2", "Check-PR-Labels"]
+    if: contains(github.event.pull_request.labels.*.name, 'v2')
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-JumpCloud.SDK.V2
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
+      - name: Unzip JumpCloud.SDK.V2 module
+        shell: pwsh
+        run: |
+          Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V2.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-JumpCloud.SDK.V1
+          path: /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/
+      - name: Unzip V1 module for V2 Tests
+        shell: pwsh
+        run: |
+          Expand-Archive -Path /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/JumpCloud.SDK.V1.zip -DestinationPath /home/runner/work/jcapi-powershell/jcapi-powershell/SDKs/PowerShell/ -Force
+      - name: Test MTP JumpCloud.SDK.V2
+        shell: pwsh
+        env:
+          PESTER_APIKEY: ${{ secrets.PESTER_APIKEY }}
+          PESTER_ORGID: ${{ secrets.PESTER_ORGID }}
+          PESTER_MSP_APIKEY: ${{ secrets.PESTER_MSP_APIKEY }}
+          PESTER_PROVIDERID: ${{ secrets.PESTER_PROVIDERID }}
+        run: |
+          $ErrorActionnPreference = 'Stop'
+          ./Test-Module.ps1 -JCApiKey:($env:PESTER_APIKEY) -JCOrgId:($env:PESTER_ORGID) -JCApiKeyMTP:($env:PESTER_MSP_APIKEY) -JCProviderId:($env:PESTER_PROVIDERID) -ExcludeTagList:("None") -IncludeTagList:("MTP") -testModulePath:("./SDKs/PowerShell/JumpCloud.SDK.V2/test-module.ps1")

--- a/.github/workflows/jcapi-powershell-release.yml
+++ b/.github/workflows/jcapi-powershell-release.yml
@@ -153,7 +153,7 @@ jobs:
           VERSION=$(echo "$MODULE_CAPTURE" | grep -Po "(\d+\.\d+\.\d+)")
           TITLE="${SDK_NAME}-${VERSION}"
           TAG="${SDK_NAME}-${VERSION}"
-          CHANGELOG=$(cat "${{ github.workspace }}/${SDK_NAME}.md" | awk "/^## ${SDK_NAME}-${VERSION}/{f=1; next} /^## ${SDK_NAME}-[0-g]+.[0-9]+.[0-9]+/{f=0} f")
+          CHANGELOG=$(cat "${{ github.workspace }}/${SDK_NAME}.md" | awk "/^## ${SDK_NAME}-${VERSION}/{f=1; next} /^## ${SDK_NAME}-[0-9]+.[0-9]+.[0-9]+/{f=0} f")
           gh release create "$TAG" --title "$TITLE" --notes "$CHANGELOG" --draft "${{ github.workspace }}/SDKs/PowerShell/${SDK_NAME}.zip"
 
   # =================================================================

--- a/.github/workflows/jcapi-powershell-release.yml
+++ b/.github/workflows/jcapi-powershell-release.yml
@@ -3,7 +3,7 @@ name: Release and Publish SDKs
 on:
   pull_request:
     types:
-      - closed
+        - closed
     branches:
       - master
 jobs:
@@ -11,112 +11,251 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'SDK')
     steps:
-      - run: echo "Building SDKs"
-  Check-If-Merged:
-    needs: ['Filter-Branch']
+      - run: echo "SDK label found. Continuing..."
+  Check-PR-Labels:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    steps:
-      - name: Check if Merged
-        run: echo {GITHUB_HEAD_REF} merged into master
-  Check-PR-Labels:
-    needs: ["Check-If-Merged"]
-    runs-on: ubuntu-latest
     outputs:
-      RELEASE_TYPE: ${{ steps.validate.outputs.RELEASE_TYPE }}
+      RELEASE_TYPE: ${{ steps.set_labels.outputs.RELEASE_TYPE }}
+      V1: ${{ steps.set_labels.outputs.V1 }}
+      V2: ${{ steps.set_labels.outputs.V2 }}
+      DIRECTORYINSIGHTS: ${{ steps.set_labels.outputs.DIRECTORYINSIGHTS }}
     steps:
-      - name: Validate-PR-Version-Labels
-        id: validate
+      - name: Set Environment Variables from PR Labels
+        id: set_labels
         shell: pwsh
         run: |
-          $PR_LABEL_LIST=$(curl -s "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" | jq -r '.[].name')
-          if ("SDK" -in $PR_LABEL_LIST) {
-              write-host "Starting Build for PowerShell SDK Release"
-          }
-          # validate type from label list:
-          $types = @('major', 'minor', 'patch', 'manual')
+          # Fetch and natively parse the JSON list of labels from the PR
+          $jsonResponse = curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" `
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels"
+          $PR_LABEL_LIST = ($jsonResponse | ConvertFrom-Json).name
+          Write-Host "Found labels on PR: $($PR_LABEL_LIST -join ', ')"
+
+          # --- Set Release Type Environment Variable using a loop ---
+          $validReleaseTypes = @('major', 'minor', 'patch', 'manual')
+          $validSdkTypes = @('v1', 'v2', 'DirectoryInsights')
+          $foundReleaseType = ''
           $typeCount = 0
-          foreach ($item in $PR_LABEL_LIST) {
-              if ($item -in $types) {
-                  write-host "$item"
-                  $typeCount += 1
-                  $RELEASE_TYPE = $item
+          $sdkTypeCount = 0
+
+          # Loop through the labels found on the PR
+          foreach ($label in $PR_LABEL_LIST) {
+              # Check if the current label is a valid release type
+              if ($label -in $validReleaseTypes) {
+                  $typeCount++
+                  $foundReleaseType = $label
+              }
+              # Check if the current label is a valid SDK type
+              if ($label -in $validSdkTypes) {
+                  $sdkTypeCount++
               }
           }
+
+          # Validate that exactly one release type was found
           if ($typeCount -eq 1) {
-              echo "RELEASE_TYPE=$RELEASE_TYPE" >> $env:GITHUB_OUTPUT
+              Write-Host "Release Type set to: $foundReleaseType"
+              echo "RELEASE_TYPE=$foundReleaseType" >> $env:GITHUB_OUTPUT
           } else {
-              throw "Multiple or invalid release types were found on PR"
-              exit 1
+              throw "Error: Expected exactly one release type label (major, minor, patch, manual), but found $typeCount."
+          }
+
+          # Validate that only one SDK type was found
+          if ($sdkTypeCount -gt 1) {
+              throw "Error: Expected only one SDK type label (v1, v2, DirectoryInsights), but found $sdkTypeCount."
+          }
+
+          # --- Set Module Environment Variables ---
+          if ('v1' -in $PR_LABEL_LIST) {
+            Write-Host "Module label 'v1' found"
+            echo "v1=true" >> $env:GITHUB_OUTPUT
+          }
+          if ('v2' -in $PR_LABEL_LIST) {
+            Write-Host "Module label 'v2' found"
+            echo "v2=true" >> $env:GITHUB_OUTPUT
+          }
+          if ('DirectoryInsights' -in $PR_LABEL_LIST) {
+            Write-Host "Module label 'DirectoryInsights' found"
+            echo "directoryinsights=true" >> $env:GITHUB_OUTPUT
           }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  Draft-GH-Release:
+
+  # =================================================================
+  # == DRAFT GITHUB RELEASE JOBS
+  # =================================================================
+
+  Draft-Release-V1:
     needs: ['Check-PR-Labels']
+    if: needs.Check-PR-Labels.outputs.V1 == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        sdkName: ['JumpCloud.SDK.V1','JumpCloud.SDK.V2','JumpCloud.SDK.DirectoryInsights']
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - name: Zip SDK Directory
         run: |
-          cd ${{ github.workspace }}/SDKs/PowerShell/${{ matrix.sdkName }}/;
-          zip -r ${{ github.workspace }}/SDKs/PowerShell/${{ matrix.sdkName }}.zip ./*
-      - name: Build Draft Release
-        run: |
-          MODULE_CAPTURE=$(grep -Po "ModuleVersion = '(\d+\.\d+\.\d+)'" ${{ github.workspace }}/SDKs/PowerShell/${{ matrix.sdkName }}/${{ matrix.sdkName }}.psd1)
-          VERSION=$(echo $MODULE_CAPTURE | grep -Po "(\d+\.\d+\.\d+)")
-          TITLE="${{ matrix.sdkName }}-$VERSION"
-          # Get the changelog text between the latest release # and the next sequential "## SemanticVersionNumber"
-          CHANGELOG=$(cat ${{ github.workspace }}/${{ matrix.sdkName }}.md | awk "/^## ${{ matrix.sdkName }}-$VERSION/{ f = 1; next } /## ${{ matrix.sdkName }}-[0-9]+.[0-9]+.[0-9]+/{ f = 0 } f")
-          BODY="$TITLE $CHANGELOG"
-          TAG="${{ matrix.sdkName }}-$VERSION"
-          BODY="$TITLE $CHANGELOG"
-          # draft release
-          (gh release view $TAG && echo "Release exists for $TAG") || gh release create $TAG --title "$TITLE" --notes "$BODY" --draft
-          # add artifact:
-          gh release upload $TAG ${{ github.workspace }}/SDKs/PowerShell/${{ matrix.sdkName }}.zip
+          cd ${{ github.workspace }}/SDKs/PowerShell/JumpCloud.SDK.V1/
+          zip -r ${{ github.workspace }}/SDKs/PowerShell/JumpCloud.SDK.V1.zip ./*
+      - name: Build and Draft Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SDK_NAME="JumpCloud.SDK.V1"
+          MODULE_CAPTURE=$(grep -Po "ModuleVersion = '(\d+\.\d+\.\d+)'" "${{ github.workspace }}/SDKs/PowerShell/${SDK_NAME}/${SDK_NAME}.psd1")
+          VERSION=$(echo "$MODULE_CAPTURE" | grep -Po "(\d+\.\d+\.\d+)")
+          TITLE="${SDK_NAME}-${VERSION}"
+          TAG="${SDK_NAME}-${VERSION}"
+          CHANGELOG=$(cat "${{ github.workspace }}/${SDK_NAME}.md" | awk "/^## ${SDK_NAME}-${VERSION}/{f=1; next} /^## ${SDK_NAME}-[0-9]+.[0-9]+.[0-9]+/{f=0} f")
+          gh release create "$TAG" --title "$TITLE" --notes "$CHANGELOG" --draft "${{ github.workspace }}/SDKs/PowerShell/${SDK_NAME}.zip"
+
+  Draft-Release-V2:
+    needs: ['Check-PR-Labels']
+    if: needs.Check-PR-Labels.outputs.V2 == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - name: Zip SDK Directory
+        run: |
+          cd ${{ github.workspace }}/SDKs/PowerShell/JumpCloud.SDK.V2/
+          zip -r ${{ github.workspace }}/SDKs/PowerShell/JumpCloud.SDK.V2.zip ./*
+      - name: Build and Draft Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SDK_NAME="JumpCloud.SDK.V2"
+          MODULE_CAPTURE=$(grep -Po "ModuleVersion = '(\d+\.\d+\.\d+)'" "${{ github.workspace }}/SDKs/PowerShell/${SDK_NAME}/${SDK_NAME}.psd1")
+          VERSION=$(echo "$MODULE_CAPTURE" | grep -Po "(\d+\.\d+\.\d+)")
+          TITLE="${SDK_NAME}-${VERSION}"
+          TAG="${SDK_NAME}-${VERSION}"
+          CHANGELOG=$(cat "${{ github.workspace }}/${SDK_NAME}.md" | awk "/^## ${SDK_NAME}-${VERSION}/{f=1; next} /^## ${SDK_NAME}-[0-9]+.[0-9]+.[0-9]+/{f=0} f")
+          gh release create "$TAG" --title "$TITLE" --notes "$CHANGELOG" --draft "${{ github.workspace }}/SDKs/PowerShell/${SDK_NAME}.zip"
+
+  Draft-Release-DI:
+    needs: ['Check-PR-Labels']
+    if: needs.Check-PR-Labels.outputs.DIRECTORYINSIGHTS == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - name: Zip SDK Directory
+        run: |
+          cd ${{ github.workspace }}/SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights/
+          zip -r ${{ github.workspace }}/SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights.zip ./*
+      - name: Build and Draft Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SDK_NAME="JumpCloud.SDK.DirectoryInsights"
+          MODULE_CAPTURE=$(grep -Po "ModuleVersion = '(\d+\.\d+\.\d+)'" "${{ github.workspace }}/SDKs/PowerShell/${SDK_NAME}/${SDK_NAME}.psd1")
+          VERSION=$(echo "$MODULE_CAPTURE" | grep -Po "(\d+\.\d+\.\d+)")
+          TITLE="${SDK_NAME}-${VERSION}"
+          TAG="${SDK_NAME}-${VERSION}"
+          CHANGELOG=$(cat "${{ github.workspace }}/${SDK_NAME}.md" | awk "/^## ${SDK_NAME}-${VERSION}/{f=1; next} /^## ${SDK_NAME}-[0-g]+.[0-9]+.[0-9]+/{f=0} f")
+          gh release create "$TAG" --title "$TITLE" --notes "$CHANGELOG" --draft "${{ github.workspace }}/SDKs/PowerShell/${SDK_NAME}.zip"
+
+  # =================================================================
+  # == MANUAL APPROVAL GATE
+  # =================================================================
+
   Manual-Approval-Release:
-    needs: ["Draft-GH-Release"]
+    needs: [Draft-Release-V1, Draft-Release-V2, Draft-Release-DI]
+    if: always() && (needs.Draft-Release-V1.result == 'success' || needs.Draft-Release-V2.result == 'success' || needs.Draft-Release-DI.result == 'success')
     environment: PublishToPSGallery
     runs-on: ubuntu-latest
     steps:
       - name: Manual Approval for Release
-        run: echo "Awaiting approval from required reviewers before continuing"
-  Deploy-Nupkg:
-    needs: ['Manual-Approval-Release']
+        run: echo "Awaiting approval from required reviewers before continuing to publish."
+
+  # =================================================================
+  # == DEPLOY NUPKG JOBS
+  # =================================================================
+
+  Deploy-V1:
+    needs: [Draft-Release-V1, Manual-Approval-Release]
+    if: always() && needs.Draft-Release-V1.result == 'success' && needs.Manual-Approval-Release.result == 'success'
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-          SDKName: ['JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2']
     steps:
       - name: Download SDK Artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           WF_NAME="jcapi-powershell-ci.yml"
-          ARTIFACT_NAME="build-${{ matrix.SDKName }}"
+          SDK_NAME="JumpCloud.SDK.V1"
+          ARTIFACT_NAME="build-$SDK_NAME"
           RUN_ID=`gh run --repo ${{ github.repository }} list --workflow ${WF_NAME} --branch ${{ github.head_ref }} --json databaseId --jq .[0].databaseId`
           gh run --repo ${{ github.repository }} download ${RUN_ID} -n ${ARTIFACT_NAME}
           # List the artifiact directory/files
           ls -lR
-          unzip ${{ matrix.SDKName }}.zip
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish SDKs
+          unzip "$SDK_NAME.zip"
+      - name: Publish SDK to PSGallery
         shell: pwsh
-        run: |
-          # add nuget source for PSGallery:
-          dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
-          # get nupkg artifact:
-          $NupkgPath = (Get-ChildItem -Path:("./${{ matrix.sdkName }}/bin/nupkg/${{ matrix.sdkName }}*.nupkg")).FullName
-          # validate package
-          $nupkgPath | Should -Exist
-          Write-Host "Nupkg Artifact Restored: $nupkgPath"
-          write-host "push ${{ matrix.sdkName }} to PSGallery"
-          # nuget push:
-          dotnet nuget push $NupkgPath --source PSGallery --api-key $env:NuGetApiKey
         env:
           NuGetApiKey: ${{ secrets.NUGETAPIKEY }}
+        run: |
+          $SDK_NAME = "JumpCloud.SDK.V1"
+          dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
+          $nupkgPath = (Get-ChildItem -Path "./$SDK_NAME/bin/nupkg/$($SDK_NAME)*.nupkg").FullName
+          Write-Host "Nupkg Path: $nupkgPath"
+          if (-not (Test-Path $nupkgPath)) { throw "Nupkg file not found for $SDK_NAME." }
+          dotnet nuget push $nupkgPath --source PSGallery --api-key $env:NuGetApiKey
+
+  Deploy-V2:
+    needs: [Draft-Release-V2, Manual-Approval-Release]
+    if: always() && needs.Draft-Release-V2.result == 'success' && needs.Manual-Approval-Release.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download SDK Artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          WF_NAME="jcapi-powershell-ci.yml"
+          SDK_NAME="JumpCloud.SDK.V2"
+          ARTIFACT_NAME="build-$SDK_NAME"
+          RUN_ID=`gh run --repo ${{ github.repository }} list --workflow ${WF_NAME} --branch ${{ github.head_ref }} --json databaseId --jq .[0].databaseId`
+          gh run --repo ${{ github.repository }} download ${RUN_ID} -n ${ARTIFACT_NAME}
+          # List the artifiact directory/files
+          ls -lR
+          unzip "$SDK_NAME.zip"
+      - name: Publish SDK to PSGallery
+        shell: pwsh
+        env:
+          NuGetApiKey: ${{ secrets.NUGETAPIKEY }}
+        run: |
+          $SDK_NAME = "JumpCloud.SDK.V2"
+          dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
+          $nupkgPath = (Get-ChildItem -Path "./$SDK_NAME/bin/nupkg/$($SDK_NAME)*.nupkg").FullName
+          Write-Host "Nupkg Path: $nupkgPath"
+          if (-not (Test-Path $nupkgPath)) { throw "Nupkg file not found for $SDK_NAME." }
+          dotnet nuget push $nupkgPath --source PSGallery --api-key $env:NuGetApiKey
+
+  Deploy-DI:
+    needs: [Draft-Release-DI, Manual-Approval-Release]
+    if: always() && needs.Draft-Release-DI.result == 'success' && needs.Manual-Approval-Release.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download SDK Artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          WF_NAME="jcapi-powershell-ci.yml"
+          SDK_NAME="JumpCloud.SDK.DirectoryInsights"
+          ARTIFACT_NAME="build-$SDK_NAME"
+          RUN_ID=`gh run --repo ${{ github.repository }} list --workflow ${WF_NAME} --branch ${{ github.head_ref }} --json databaseId --jq .[0].databaseId`
+          gh run --repo ${{ github.repository }} download ${RUN_ID} -n ${ARTIFACT_NAME}
+          # List the artifiact directory/files
+          ls -lR
+          unzip "$SDK_NAME.zip"
+      - name: Publish SDK to PSGallery
+        shell: pwsh
+        env:
+          NuGetApiKey: ${{ secrets.NUGETAPIKEY }}
+        run: |
+          $SDK_NAME = "JumpCloud.SDK.DirectoryInsights"
+          dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
+          $nupkgPath = (Get-ChildItem -Path "./$SDK_NAME/bin/nupkg/$($SDK_NAME)*.nupkg").FullName
+          Write-Host "Nupkg Path: $nupkgPath"
+          if (-not (Test-Path $nupkgPath)) { throw "Nupkg file not found for $SDK_NAME." }
+          dotnet nuget push $nupkgPath --source PSGallery --api-key $env:NuGetApiKey

--- a/Tools/Build-SdkChangelog.ps1
+++ b/Tools/Build-SdkChangelog.ps1
@@ -65,7 +65,7 @@ elseif ($SdkChangelog -match "$LatestPsd1Version") {
     Write-Host "Updating Diffs"
     # Update the changelog Release Date
     $SdkChangelog = Get-Content -Path $SdkChangelogFilePath -Raw
-    $todaysDate = Get-Date -UFormat:('%B %d, %Y')
+    $todaysDate = Get-Date -UFormat "%B %d, %Y"
     $SdkChangelog = $SdkChangelog -replace ("Release Date:.*"), "Release Date: $todaysDate"
     # Update the changelog with the new diffs
     $SdkChangelog | Set-Content -Path $SdkChangelogFilePath -Force

--- a/Tools/Build-SdkChangelog.ps1
+++ b/Tools/Build-SdkChangelog.ps1
@@ -57,12 +57,19 @@ $NewSdkChangelogRecord = New-SdkChangelog -LatestVersion:($LatestPsd1Version) -R
 
 # Check if we need to post a new changelog block or update the diffs
 if ($SdkChangelog -notmatch "$LatestPsd1Version") {
-    Write-Host "Latest Release Version: $LatestPsd1Version differs from changlog version $LatestVersionInChangelog"
+    Write-Host "Latest Release Version: $LatestPsd1Version differs from changelog version $LatestVersionInChangelog"
     # Write-Host "Creating new changelog verion header"
     ($NewSdkChangelogRecord + ($SdkChangelog | Out-String)).Trim() | Set-Content -Path $SdkChangelogFilePath -Force
 }
 elseif ($SdkChangelog -match "$LatestPsd1Version") {
     Write-Host "Updating Diffs"
+    # Update the changelog Release Date
+    $SdkChangelog = Get-Content -Path $SdkChangelogFilePath -Raw
+    $todaysDate = Get-Date -UFormat:('%B %d, %Y')
+    $SdkChangelog = $SdkChangelog -replace ("Release Date:.*"), "Release Date: $todaysDate"
+    # Update the changelog with the new diffs
+    $SdkChangelog | Set-Content -Path $SdkChangelogFilePath -Force
+
     # Get the current version content up to the last version content
     $LastChangeRegex = [regex]"## $LatestPsd1Version[\s\S]*?(?=## $sdkname-)"
     $ChangeLogContent = Select-String -InputObject $SdkChangelog -Pattern $LastChangeRegex

--- a/Tools/Build.ps1
+++ b/Tools/Build.ps1
@@ -1,24 +1,42 @@
 [CmdletBinding()]
 param (
-    [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = 'Name of the API to build an SDK for.', ParameterSetName = 'IndividualSDK')][ValidateSet('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2')][ValidateNotNullOrEmpty()][System.String[]]$SDKName
+    [Parameter(Mandatory = $true, HelpMessage = 'The type of version bump.')]
+    [ValidateSet('major', 'minor', 'patch', 'manual')]
+    [System.String]
+    $VersionType,
+
+    [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = 'Name of the API to build an SDK for.', ParameterSetName = 'IndividualSDK')]
+    [ValidateSet('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2')]
+    [ValidateNotNullOrEmpty()]
+    [System.String[]]
+    $SDKName
 )
 
-# build all SDKs if no individual SDK is specified
-if (!$SDKName){
+# If no individual SDK is specified, build all of them.
+if (!$SDKName) {
     $sdks = @('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2')
-} else {
+}
+else {
     $sdks = $SDKName
 }
+
+# Store the current path to return to it after the script finishes.
 $pathBeforeRun = $pwd
-# Build each of the specified SDKs:
 $rootPath = "$PSScriptRoot/../"
-foreach ($sdk in $sdks){
-    # invoke Build Autorest
-    . "$rootPath/BuildAutoRest.ps1" -SDKName $sdk | Out-Null
-    # update SDK Examples:
+
+# Build each of the specified SDKs.
+foreach ($sdk in $sdks) {
+    Write-Host "Building $sdk with version type: $VersionType"
+
+    # Invoke Build Autorest and pass the version type.
+    . "$rootPath/BuildAutoRest.ps1" -SDKName $sdk -VersionType $VersionType | Out-Null
+
+    # Update SDK Examples and pass the version type.
     . "$PSscriptRoot/Build-SdkExamples" -SDKName $sdk | Out-Null
-    # update module changelog
+
+    # Update module changelog and pass the version type.
     . "$PSscriptRoot/Build-SdkChangelog" -SDKName $sdk | Out-Null
 }
-# CD back to the directory before building the SDKs
+
+# Return to the original directory.
 Set-Location $pathBeforeRun

--- a/Tools/ModuleValidation.Tests.ps1
+++ b/Tools/ModuleValidation.Tests.ps1
@@ -1,116 +1,97 @@
-
-Describe -Tag:('ModuleValidation') 'Module Manifest Tests' {
-    It ('Validates Module Versions'){
-        [version]$v1GalleryVersion = Find-Module -name JumpCloud.SDK.V1 | Select-Object -Property Version | ForEach-Object { $_.Version }
-        # Compare the versions to SDKs/PowerShell/JumpCloud.SDK.V1/JumpCloud.SDK.V1.psd1
-        [version]$V1LocalVersion = Get-Content -Path "./SDKs/PowerShell/JumpCloud.SDK.V1/JumpCloud.SDK.V1.psd1" | Select-String -Pattern "ModuleVersion = '(.*)'" | ForEach-Object { $_.Matches.Groups[1].Value }
-
-        # Compare the versions to SDKs/PowerShell/JumpCloud.SDK.V2/JumpCloud.SDK.V2.psd1
-        [version]$v2GalleryVersion = Find-Module -name JumpCloud.SDK.V2 | Select-Object -Property Version | ForEach-Object { $_.Version }
-        [version]$V2LocalVersion = Get-Content -Path "./SDKs/PowerShell/JumpCloud.SDK.V2/JumpCloud.SDK.V2.psd1" | Select-String -Pattern "ModuleVersion = '(.*)'" | ForEach-Object { $_.Matches.Groups[1].Value }
-
-        # Compare the versions to SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights/JumpCloud.SDK.DirectoryInsights.psd1
-        [version]$DiGalleryVersion = Find-Module -name JumpCloud.SDK.DirectoryInsights | Select-Object -Property Version | ForEach-Object { $_.Version }
-        [version]$DiLocalVersion = Get-Content -Path "./SDKs/PowerShell/JumpCloud.SDK.DirectoryInsights/JumpCloud.SDK.DirectoryInsights.psd1" | Select-String -Pattern "ModuleVersion = '(.*)'" | ForEach-Object { $_.Matches.Groups[1].Value }
-
-
-        switch ($env:RELEASE_TYPE) {
-            'major' {
-                $V1LocalVersion.Major | Should -Be ($v1GalleryVersion.Major + 1)
-                $V2LocalVersion.Major | Should -Be ($v2GalleryVersion.Major + 1)
-                $DiLocalVersion.Major | Should -Be ($DiGalleryVersion.Major + 1)
-
-                $V1LocalVersion | Should -BeGreaterThan $v1GalleryVersion
-                $V2LocalVersion | Should -BeGreaterThan $v2GalleryVersion
-                $DiGalleryVersion | Should -BeGreaterThan $DiGalleryVersion
-            }
-            'minor' {
-                $V1LocalVersion.Minor | Should -Be ($v1GalleryVersion.Minor + 1)
-                $V2LocalVersion.Minor | Should -Be ($v2GalleryVersion.Minor + 1)
-                $DiLocalVersion.Minor | Should -Be ($DiGalleryVersion.Minor + 1)
-
-                $V1LocalVersion | Should -BeGreaterThan $v1GalleryVersion
-                $V2LocalVersion | Should -BeGreaterThan $v2GalleryVersion
-                $DiGalleryVersion | Should -BeGreaterThan $DiGalleryVersion
-            }
-            'patch' {
-                #Test
-                $V1LocalVersion.Build | Should -Be ($v1GalleryVersion.Build + 1)
-                $V2LocalVersion.Build | Should -Be ($v2GalleryVersion.Build + 1)
-                $DiLocalVersion.Build | Should -Be ($DiGalleryVersion.Build + 1)
-
-                $V1LocalVersion | Should -BeGreaterThan $v1GalleryVersion
-                $V2LocalVersion | Should -BeGreaterThan $v2GalleryVersion
-                $DiLocalVersion | Should -BeGreaterThan $DiGalleryVersion
-
-
+    Describe -Tag:('ModuleValidation') 'Module Validation'  {
+        BeforeAll {
+            if ($env:v1 -eq 'true') {
+                $moduleName = 'JumpCloud.SDK.V1'
+            } elseif ($env:v2 -eq 'true') {
+                $moduleName = 'JumpCloud.SDK.V2'
+            } elseif ($env:directoryinsights -eq 'true') {
+                $moduleName = 'JumpCloud.SDK.DirectoryInsights'
+            } else {
+                Write-Error "No valid module label found in the environment variables. Exiting."
+                Exit 1
             }
         }
-    }
-    It 'The data on the current version of the Module Changelog should be todays date' {
-        if ($env:RELEASE_TYPE) {
-            @('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2')| ForEach-Object {
-                $latestModule = Find-Module -Name $_
-                $rootPath = "$PSScriptRoot/../"
-                $moduleChangelogPath = "$rootPath/$_.md"
-                $moduleChangelogContent = Get-Content ("$moduleChangelogPath") -TotalCount 3
-                # latest from changelog
-                $stringMatch = Select-String -InputObject $moduleChangelogContent -Pattern "## $_-([0-9]+.[0-9]+.[0-9]+)"
-                $latestChangelogVersion = $stringMatch.matches.groups[1].value
-                $stringMatch = Select-String -InputObject $moduleChangelogContent -Pattern "Release Date: (.*) ####"
-                $latestReleaseDate = $stringMatch.matches.groups[1].value
-                switch ($env:RELEASE_TYPE) {
+        It "validates the module version against the gallery based on the release type" {
+            # Find the currently published version on the PowerShell Gallery.
+            # Use -ErrorAction SilentlyContinue for cases where the module isn't published yet (e.g., first release).
+            $galleryModule = Find-Module -Name $moduleName -ErrorAction SilentlyContinue
+            $galleryVersion = if ($null -ne $galleryModule) { [version]$galleryModule.Version } else { [version]'0.0.0' }
+
+            # Get the local version from the module manifest (.psd1 file).
+            $psd1Path = Join-Path $PSScriptRoot '..' 'SDKs' 'PowerShell' $moduleName "$moduleName.psd1"
+            $localVersionString = (Get-Content -Path $psd1Path | Select-String -Pattern "ModuleVersion\s*=\s*'(.*)'").Matches.Groups[1].Value
+            [version]$localVersion = $localVersionString
+
+            # Assertion: The local version must always be greater than the published version.
+            $localVersion | Should -BeGreaterThan $galleryVersion
+
+            # If a release type is specified, validate the version increment is correct according to SemVer.
+            if ($env:RELEASE_TYPE) {
+                switch ($env:RELEASE_TYPE.ToLower()) {
                     'major' {
-                        $versionString = "$($(([version]$latestModule.Version).Major) + 1).0.0"
-                        Write-Host "[Module Validation Tests] Development Version Major Changelog Version: $($latestChangelogVersion) Should be $versionString"
-                        ([Version]$latestChangelogVersion).Major | Should -Be (([version]$latestModule.Version).Major + 1)
-                        ([Version]$latestChangelogVersion) | Should -BeGreaterThan (([version]$latestModule.Version))
+                        $localVersion.Major | Should -Be ($galleryVersion.Major + 1) "for a 'major' release"
+                        $localVersion.Minor | Should -Be 0 "for a 'major' release"
+                        $localVersion.Build | Should -Be 0 "for a 'major' release"
                     }
                     'minor' {
-                        $versionString = "$($(([version]$latestModule.Version).Major)).$(([version]$latestModule.Version).minor + 1).0"
-                        Write-Host "[Module Validation Tests] Development Version Minor Changelog Version: $($latestChangelogVersion) Should be $versionString"
-                        ([Version]$latestChangelogVersion).Minor | Should -Be (([version]$latestModule.Version).Minor + 1)
-                        ([Version]$latestChangelogVersion) | Should -BeGreaterThan (([version]$latestModule.Version))
+                        $localVersion.Major | Should -Be $galleryVersion.Major "for a 'minor' release"
+                        $localVersion.Minor | Should -Be ($galleryVersion.Minor + 1) "for a 'minor' release"
+                        $localVersion.Build | Should -Be 0 "for a 'minor' release"
                     }
                     'patch' {
-                        $versionString = "$($(([version]$latestModule.Version).Major)).$(([version]$latestModule.Version).minor).$(([version]$latestModule.Version).Build + 1)"
-                        Write-Host "[Module Validation Tests] Development Version Build Changelog Version: $($latestChangelogVersion) Should be $versionString"
-                        ([Version]$latestChangelogVersion).Build | Should -Be (([version]$latestModule.Version).Build + 1)
-                        ([Version]$latestChangelogVersion) | Should -BeGreaterThan (([version]$latestModule.Version))
-                    }
-                    'manual' {
-                        Write-Host "[Module Validation Tests] Development Version Changelog Version: $($latestChangelogVersion) is going to be manually released to PowerShell Gallery"
-                        ([Version]$latestChangelogVersion) | Should -BeGreaterThan (([version]$latestModule.Version))
+                        # In SemVer, 'patch' is the third component. In the .NET [version] class, this corresponds to 'Build'.
+                        $localVersion.Major | Should -Be $galleryVersion.Major "for a 'patch' release"
+                        $localVersion.Minor | Should -Be $galleryVersion.Minor "for a 'patch' release"
+                        $localVersion.Build | Should -Be ($galleryVersion.Build + 1) "for a 'patch' release"
                     }
                 }
-                $todayDate = Get-Date -UFormat "%B %d, %Y"
-                # if ($todayDate | Select-String -Pattern "0\d,") {
-                #     $todayDate = "$(Get-Date -UFormat %B) $($(Get-Date -Uformat %d) -replace '0', ''), $(Get-Date -UFormat %Y)"
-                # }
-                $latestReleaseDate | Should -Be $todayDate
+            }
+        }
+
+        It "validates the changelog has the correct new version and today's date" {
+            # This test only runs if a release type that requires a changelog entry is specified.
+            if (-not ($env:RELEASE_TYPE -in @('major', 'minor', 'patch'))) {
+                Skip "Skipping changelog validation because release type is not 'major', 'minor', or 'patch'."
             }
 
+            $galleryModule = Find-Module -Name $moduleName -ErrorAction SilentlyContinue
+            $galleryVersion = if ($null -ne $galleryModule) { [version]$galleryModule.Version } else { [version]'0.0.0' }
+
+            $changelogPath = Join-Path $PSScriptRoot '..' "$moduleName.md"
+            $changelogContent = Get-Content -Path $changelogPath -TotalCount 5 # Read a few lines from the top
+
+            # Validate the version in the changelog header.
+            $changelogLine = $changelogContent | Select-String -Pattern "## $moduleName-([0-9]+\.[0-9]+\.[0-9]+)"
+            $changelogLine | Should -Not -BeNullOrEmpty "because the changelog should contain a version header like '## $moduleName-x.y.z'"
+            [version]$latestChangelogVersion = $changelogLine.Matches.Groups[1].Value
+            $latestChangelogVersion | Should -BeGreaterThan $galleryVersion
+
+            # Validate the release date is today.
+            $latestReleaseDate = (Select-String -InputObject $changelogContent -Pattern "Release Date: (.*) ####").Matches.Groups[1].Value
+            $todayDate = Get-Date -UFormat "%B %d, %Y"
+            $latestReleaseDate | Should -Be $todayDate
         }
-    }
-    It 'The ModuleChangeLog Congent should not contain placeholder content'{
-        $rootPath = "$PSScriptRoot/../"
-        @('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2') | ForEach-Object {
-            $moduleChangelogPath = "$rootPath/$_.md"
-            $moduleChangelogContent = Get-Content ("$moduleChangelogPath")
-            $moduleChangelogContent | Should -Not -Match "{{Fill in the"
+
+        It "ensures the changelog does not contain placeholder content" {
+            $changelogPath = Join-Path $PSScriptRoot '..' "$moduleName.md"
+            Get-Content -Path $changelogPath | Should -Not -Match '\{\{Fill in the'
         }
-    }
-    It 'Runs API Transform and validates no changes in SwaggerSpec exist (branch is up to date with public docs)'{
-        $rootPath = "$PSScriptRoot/../"
-        @('JumpCloud.SDK.DirectoryInsights', 'JumpCloud.SDK.V1', 'JumpCloud.SDK.V2') | ForEach-Object {
-            . "$rootpath/ApiTransform.ps1" -SDKName $_ 3>$null
-            $sdkSwaggerFile = "$rootpath/SwaggerSpecs/$_.json"
+
+        It "ensures the Swagger spec is up to date with no pending changes" {
+            # Note: Assumes dependent scripts are in the parent directory of this test script.
+            . (Join-Path $PSScriptRoot '..' 'ApiTransform.ps1') -SDKName $moduleName 3>$null
+            $sdkSwaggerFile = Join-Path $PSScriptRoot '..' 'SwaggerSpecs' "$moduleName.json"
+
             $currentBranch = git rev-parse --abbrev-ref HEAD
-            $changes = git diff -I "collection_time" -I "dueDate" $currentBranch -- $sdkSwaggerFile
-            if ($changes){
-                Write-Warning "Git Diff changes found in /SwaggerSpecs/$_.json have you run build.ps1 today?"
+
+            # Compare the generated spec file with the version committed to the current branch.
+            # Ignore keys that have dynamic values like timestamps.
+            $gitDiffOutput = git diff --ignore-matching-lines='collection_time' --ignore-matching-lines='dueDate' $currentBranch -- $sdkSwaggerFile
+
+            if ($gitDiffOutput) {
+                Write-Warning "Git Diff found changes in /SwaggerSpecs/$moduleName.json. Please run the build script to ensure it is up to date."
             }
-            $changes | should -BeNullOrEmpty
+
+            $gitDiffOutput | Should -BeNullOrEmpty "because the Swagger spec file should have no pending changes after a build."
         }
     }
-}


### PR DESCRIPTION
## Issues
* [CUT-4530](https://jumpcloud.atlassian.net/browse/CUT-4530) - CUT-4530

## What does this solve?
This enables independent SDK releases, avoiding unnecessary builds and releases of all three SDKs when only one needs an update.
## Is there anything particularly tricky?
N/A
## How should this be tested?
I can demo or walkthrough the changes. A bunch of the CI tests are also available to be checked.
## Screenshots

V2 build (dependency: V1):
<img width="751" alt="image" src="https://github.com/user-attachments/assets/9ced0c55-b14c-4a57-9327-95211c4a2b07" />
Downloaded v1 dependency for v2 test from PSGallery
<img width="815" alt="image" src="https://github.com/user-attachments/assets/a8c43fa8-8b5e-4a92-9f80-73590ec3eb9a" />

V1 Release:

<img width="748" alt="image" src="https://github.com/user-attachments/assets/b71d10a2-0737-4788-b8b4-583c6473ea65" />




[CUT-4530]: https://jumpcloud.atlassian.net/browse/CUT-4530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ